### PR TITLE
drop clojurescript.test for cljs.test

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ __CLJS needs a pretty printer__ - Clojure has two pretty-printers available, whi
 
 [See docs for more notes](docs/)
 
+## Running the tests
+
+Node.js must be installed.
+
+```sh
+lein cljsbuild once test
+```
+
 ## Running
 
 ```sh

--- a/project.clj
+++ b/project.clj
@@ -5,19 +5,18 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2665"]
+  :dependencies [[org.clojure/clojure "1.7.0-beta2"]
+                 [org.clojure/clojurescript "0.0-3211"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [hiccups "0.3.0"]
                  [fipp "0.5.2"]
-                 [figwheel "0.2.3-SNAPSHOT"]
+                 [figwheel "0.2.9"]
                  [cljs-ajax "0.3.10"]
                  [markdown-clj "0.9.62"]
                  [cljsjs/jquery "1.9.0-0"]]
 
-  :plugins [[lein-cljsbuild "1.0.4"]
-            [lein-figwheel "0.2.3-SNAPSHOT"]
-            [com.cemerick/clojurescript.test "0.3.3"]]
+  :plugins [[lein-cljsbuild "1.0.5"]
+            [lein-figwheel "0.2.9"]]
 
   :source-paths ["src/parse"]
   :main parse.core
@@ -29,16 +28,17 @@
                                     "resources/report/js/report.js"]
 
   :cljsbuild
-  {:test-commands {"test" ["phantomjs" :runner "resources/test/pprint.test.js"]}
+  {:test-commands {"test" ["node" :runner "resources/test/pprint.test.js"]}
 
    :builds
    [{:id "test"
      :source-paths ["src/cljs" "test/cljs"]
+     :notify-command ["node" "resources/test/pprint.test.js"]
      :compiler
      {:output-to  "resources/test/pprint.test.js"
       :source-map "resources/test/pprint.test.js.map"
       :output-dir "resources/test/out"
-      :optimizations :whitespace}}
+      :optimizations :simple}}
 
     {:id "report"
      :source-paths ["src/report" "src/report_dev"]

--- a/src/cljs/cljs/pprint.cljs
+++ b/src/cljs/cljs/pprint.cljs
@@ -15,7 +15,7 @@
   (:require
     [cljs.core :refer [IWriter IDeref]]
     [clojure.string :as string])
-  (:import goog.string.StringBuffer))
+  (:import [goog.string StringBuffer]))
 
 (def ^:dynamic *out* nil)
 

--- a/test/cljs/cljs/pprint_test.clj
+++ b/test/cljs/cljs/pprint_test.clj
@@ -1,6 +1,5 @@
 (ns cljs.pprint-test
-  (:require
-    [cemerick.cljs.test :refer [deftest is]]))
+  (:require [cljs.test :refer [deftest is]]))
 
 (defmacro simple-tests [name & test-pairs]
   `(deftest ~name

--- a/test/cljs/cljs/pprint_test.cljs
+++ b/test/cljs/cljs/pprint_test.cljs
@@ -1,14 +1,14 @@
 (ns cljs.pprint-test
   (:refer-clojure :exclude [prn])
+  (:require-macros
+    [cljs.pprint-test :refer [simple-tests]])
   (:require
-    [cemerick.cljs.test :as t]
+    [cljs.test :as t :refer-macros [deftest is run-tests]]
     [cljs.pprint :refer [pprint cl-format *out* get-pretty-writer prn print-table
                          *print-pprint-dispatch* simple-dispatch
                          *print-right-margin* *print-miser-width*]])
-  (:require-macros
-    [cemerick.cljs.test :refer [deftest is]]
-    [cljs.pprint-test :refer [simple-tests]])
-  (:import goog.string.StringBuffer))
+
+  (:import [goog.string StringBuffer]))
 
 (def format cl-format)
 
@@ -980,3 +980,5 @@ Usage: *hello*
 "
   )
 
+(enable-console-print!)
+(run-tests)


### PR DESCRIPTION
This is necessary for the final patch.
